### PR TITLE
Handle messages with multiple replies

### DIFF
--- a/lib/slack_bot.ex
+++ b/lib/slack_bot.ex
@@ -55,6 +55,9 @@ defmodule Worker.SlackBot do
   defp bot_token(state), do: state.credentials.bot_access_token
   defp web_token(state), do: state.credentials.access_token
 
+  defp get_text(%{"messages" => []}), do: ""
+  defp get_text(%{"messages" => [%{"text" => text} | _]}), do: text
+
   defp get_text(%{item: %{ts: ts, channel: "G" <> _ = group}}, state) do
     get_text(@slack_web_groups_api.replies(group, ts, %{token: web_token(state)}))
   end
@@ -62,9 +65,6 @@ defmodule Worker.SlackBot do
   defp get_text(%{item: %{ts: ts, channel: channel}}, state) do
     get_text(@slack_web_channels_api.replies(channel, ts, %{token: web_token(state)}))
   end
-
-  defp get_text(%{"messages" => []}), do: ""
-  defp get_text(%{"messages" => [%{"text" => text}]}), do: text
 
   defp send_acronyms([], _, _), do: nil
 

--- a/lib/team_monitor.ex
+++ b/lib/team_monitor.ex
@@ -8,7 +8,7 @@ defmodule TeamMonitor do
   end
 
   def init(state) do
-    poll(0)
+    poll(100)
     {:ok, state}
   end
 
@@ -22,8 +22,6 @@ defmodule TeamMonitor do
   defp poll(delay \\ @delay) do
     Process.send_after(self(), :update, delay)
   end
-
-  defp start([]), do: IO.puts("No new teams")
 
   defp start(teams) do
     teams

--- a/test/slack_bot_test.exs
+++ b/test/slack_bot_test.exs
@@ -76,7 +76,7 @@ defmodule SlackBotTest do
     Worker.SlackWebApi.Channels.MockClient
     |> expect(:replies, fn @channel, @ts, _ ->
       %{
-        "messages" => Enum.map(replies, fn reply -> %{"text" => reply} end),
+        "messages" => Enum.map(replies, fn reply -> %{"text" => reply} end)
       }
     end)
   end


### PR DESCRIPTION
get_text was missing a case where there were multiple replies instead of just one.